### PR TITLE
Convert scripts using subprocess and CommandUtils

### DIFF
--- a/src/functions/finished_screen.py
+++ b/src/functions/finished_screen.py
@@ -21,6 +21,8 @@
 import subprocess, shutil
 from gi.repository import Gtk, Adw
 from gettext import gettext as _
+from jade_gui.utils.command import CommandUtils
+
 
 @Gtk.Template(resource_path='/al/getcryst/jadegui/pages/finished_screen.ui')
 class FinishedScreen(Adw.Bin):
@@ -33,4 +35,4 @@ class FinishedScreen(Adw.Bin):
         self.reboot_button.connect("clicked", self.reboot)
 
     def reboot(self, widget):
-        command=subprocess.run([shutil.which("bash"), "-c", "bash -- /app/share/jade_gui/jade_gui/scripts/reboot.sh"], capture_output=False)
+        CommandUtils.run_command(["gnome-session-quit", "--reboot"])

--- a/src/functions/install_screen.py
+++ b/src/functions/install_screen.py
@@ -21,6 +21,8 @@ import subprocess, os, shutil
 import asyncio
 from gi.repository import Gtk, GLib, Adw
 from gettext import gettext as _
+from jade_gui.utils.command import CommandUtils
+
 
 @Gtk.Template(resource_path='/al/getcryst/jadegui/pages/install_screen.ui')
 class InstallScreen(Adw.Bin):
@@ -37,7 +39,7 @@ class InstallScreen(Adw.Bin):
     def install(self):
         prefs = self.window.summary_screen.installprefs.generate_json()
         with open(os.getenv("HOME")+"/test.log", "wb") as f:
-            process = subprocess.Popen([shutil.which("bash"), "-c", "bash -- /app/share/jade-gui/jade_gui/scripts/install.sh"], stdout=subprocess.PIPE)
+            process = CommandUtils.run_command(["pkexec", "jade", "config", "~/.config/jade.json"])
             for c in iter(lambda: process.stdout.read(1), b""):
                 log=c
                 try:

--- a/src/functions/partition_screen.py
+++ b/src/functions/partition_screen.py
@@ -20,6 +20,7 @@ import subprocess, shutil
 from gi.repository import Gtk, Adw
 from gettext import gettext as _
 from jade_gui.utils import disks
+from jade_gui.utils.command import CommandUtils
 from jade_gui.widgets.partition import PartitionEntry
 from jade_gui.classes.partition import Partition
 
@@ -55,10 +56,10 @@ class PartitionScreen(Adw.Bin):
         self.open_gparted.connect("clicked", self.gparted)
 
     def gparted(self, widget):
-        subprocess.run([shutil.which("bash"), "-c", "bash -- /app/share/jade-gui/jade_gui/scripts/openGparted.sh"])
+        CommandUtils.run_command(["pkexec", "gparted"])
 
     def bash(self, widget):
-        subprocess.run([shutil.which("bash"), "-c", "bash -- /app/share/jade-gui/jade_gui/scripts/openBash.sh"])
+        CommandUtils.run_command(["gnome-terminal", "--", "bash"])
 
     def check_partitions(self, widget):
         self.partition_list.select_all()

--- a/src/utils/command.py
+++ b/src/utils/command.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+
+
+class CommandUtils:
+
+    @staticmethod
+    def run_command(command: list, flatpak_spawn: bool = None, output: bool = False, decode: bool = True):
+        """
+        Keep flatpak_spawn as None to automatically assume its value based on
+        whether the app is running in a flatpak or not. Set it to True or False
+        to override this behavior.
+        """
+        if flatpak_spawn is None and "FLATPAK_ID" in os.environ:
+            flatpak_spawn = True
+
+        if flatpak_spawn:
+            command = ["flatpak-spawn", "--host"] + command
+            
+        if output:
+            res = subprocess.check_output(command)
+            if decode:
+                res = res.decode("utf-8").strip()
+            return res
+
+        return subprocess.Popen(command, stdout=subprocess.PIPE)
+
+    @staticmethod
+    def check_output(command: list, flatpak_spawn: bool = None, decode: bool = True):
+        """Just a wrapper for convenience"""
+        return CommandUtils.run_command(command, flatpak_spawn, output=True, decode=decode)

--- a/src/utils/disks.py
+++ b/src/utils/disks.py
@@ -52,7 +52,6 @@ def get_uefi():
     return "BIOS" if output == "0" else "UEFI"
 
 def get_disk_type(disk: str):
-    #lsblk -d -o rota $1 | grep -v ROTA
     output = CommandUtils.check_output(['lsblk', '-d', '-o', 'rota', disk])
     output = output.split()
     output = [x for x in output if 'ROTA' not in x]

--- a/src/utils/meson.build
+++ b/src/utils/meson.build
@@ -5,5 +5,6 @@ jade_gui_sources = [
     '__init__.py',
     'disks.py',
     'threading.py',
+    'command.py',
 ]
 install_data(jade_gui_sources, install_dir: utilsdir)


### PR DESCRIPTION
The purpose with this PR is to avoid running scripts in the dark. The CommandUtils class can be used to automatically set-up flatpak-spawn or force its behavior.

I've tested this locally and all scripts works as before.

~~Small note: I think flatpak-spawn is not really needed since the whole app need host permissions and it will probably never land to Flathub due to being very specific. I think the best solution would be giving it permissions to reach what it need (e.g. all devices) instead of hard-coding flatpak-spawn.~~