### PR TITLE
Enable onyx for de selection

### DIFF
--- a/src/desktops.py
+++ b/src/desktops.py
@@ -1,5 +1,5 @@
 desktops = [
-#   "Onyx",
+    "Onyx",
     "GNOME",
     "Plasma",
     "Budgie",

--- a/subprojects/blueprint-compiler.wrap
+++ b/subprojects/blueprint-compiler.wrap
@@ -1,8 +1,0 @@
-[wrap-git]
-directory = blueprint-compiler
-url = https://gitlab.gnome.org/jwestman/blueprint-compiler.git
-revision = main
-depth = 1
-
-[provide]
-program_names = blueprint-compiler


### PR DESCRIPTION
This allows users to select onyx as a desktop environment to install
it also sets onyx as the default

blueprint compiler is also removed as it isn't needed anymore