### PR TITLE
set bash as default shell

### DIFF
--- a/src/classes/install_prefs.py
+++ b/src/classes/install_prefs.py
@@ -84,7 +84,7 @@ class InstallPrefs:
                     'name': self.username,
                     'password': self.password,
                     'hasroot': self.enable_sudo,
-                    'shell': 'zsh'
+                    'shell': 'bash'
                 }
             ],
             'rootpass': self.password,


### PR DESCRIPTION
Sets the default shell to bash, used to be zsh