### PR TITLE
add f2fs support

### DIFF
--- a/src/manualpartitioning.py
+++ b/src/manualpartitioning.py
@@ -10,7 +10,8 @@ filesystems = [
     "ext2",
     "ext4",
     "minix",
-    "vfat"
+    "vfat",
+    "f2fs"
 ]
 
 mountpoints = [


### PR DESCRIPTION
Allows users to use f2fs for manual partitioning, relies on https://github.com/crystal-linux/jade/pull/36 and https://github.com/crystal-linux/iso/pull/16