### PR TITLE
Run reflector before starting installation

### DIFF
--- a/src/functions/install_screen.py
+++ b/src/functions/install_screen.py
@@ -39,7 +39,7 @@ class InstallScreen(Adw.Bin):
     def install(self):
         prefs = self.window.summary_screen.installprefs.generate_json()
         with open(os.getenv("HOME")+"/jade-gui.log", "wb") as f:
-            process = CommandUtils.run_command(["pkexec", "jade", "config", os.getenv("HOME")+"/.config/jade.json"])
+            process=subprocess.run(["bash", "-c", "bash -- /app/share/jade-gui/jade_gui/scripts/install.sh"], capture_output=True)
             for c in iter(lambda: process.stdout.read(1), b""):
                 log=c
                 try:

--- a/src/functions/install_screen.py
+++ b/src/functions/install_screen.py
@@ -39,7 +39,7 @@ class InstallScreen(Adw.Bin):
     def install(self):
         prefs = self.window.summary_screen.installprefs.generate_json()
         with open(os.getenv("HOME")+"/jade-gui.log", "wb") as f:
-            process=subprocess.run(["bash", "-c", "bash -- /app/share/jade-gui/jade_gui/scripts/install.sh"], capture_output=True)
+            process=subprocess.Popen(["bash", "-c", "bash -- /app/share/jade-gui/jade_gui/scripts/install.sh"], stdout=subprocess.PIPE)
             for c in iter(lambda: process.stdout.read(1), b""):
                 log=c
                 try:

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/bash
+echo "Running reflector to sort for fastest mirrors"
+flatpak-spawn --host pkexec reflector --latest 5 --sort rate --save /etc/pacman.d/mirrorlist
 flatpak-spawn --host pkexec jade config ~/.config/jade.json


### PR DESCRIPTION
Runs reflector to ensure that the fastest mirrors are used before proceeding with the install