### PR TITLE
Fix mountpoint value in manual partitioning

### DIFF
--- a/al.getcryst.jadegui.json
+++ b/al.getcryst.jadegui.json
@@ -1,7 +1,7 @@
 {
   "app-id": "al.getcryst.jadegui",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "42",
+  "runtime-version": "43",
   "sdk": "org.gnome.Sdk",
   "command": "jade_gui",
   "finish-args": [
@@ -25,46 +25,6 @@
   ],
   "modules": [
     {
-      "name": "libadwaita",
-      "buildsystem": "meson",
-      "config-opts": [
-        "-Dexamples=false",
-        "-Dtests=false"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
-          "tag": "1.2.beta",
-          "commit": "7387b453a4c93fbb60d68ec009af6f719fe8bab9"
-        }
-      ],
-      "modules": [
-        {
-          "name": "libsass",
-          "buildsystem": "meson",
-          "sources": [
-            {
-              "type": "git",
-              "url": "https://github.com/lazka/libsass.git",
-              "branch": "meson"
-            }
-          ]
-        },
-        {
-          "name": "sassc",
-          "buildsystem": "meson",
-          "sources": [
-            {
-              "type": "git",
-              "url": "https://github.com/lazka/sassc.git",
-              "branch": "meson"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "name": "python3-pytz",
       "buildsystem": "simple",
       "sources": [
@@ -82,11 +42,6 @@
     {
       "name": "jadegui",
       "buildsystem": "meson",
-      "build-options": {
-        "build-args": [
-          "--share=network"
-        ]
-      },
       "sources": [
         {
           "type": "dir",

--- a/al.getcryst.jadegui.yml
+++ b/al.getcryst.jadegui.yml
@@ -1,66 +1,53 @@
-app-id: al.getcryst.jadegui
-runtime: org.gnome.Platform
-runtime-version: '42'
-sdk: org.gnome.Sdk
-command: jade_gui
-
-finish-args:
-    - --share=network
-    - --share=ipc
-    - --socket=fallback-x11
-    - --device=dri
-    - --socket=wayland
-    - --talk-name=org.freedesktop.Flatpak
-    - --filesystem=home:rw
-
-cleanup:
-    - /include
-    - /lib/pkgconfig
-    - /man
-    - /share/doc
-    - /share/gtk-doc
-    - /share/pkgconfig
-    - "*.la"
-    - "*.a"
-
-modules:
-    - name: libadwaita
-      buildsystem: meson
-      config-opts:
-        - -Dexamples=false
-        - -Dtests=false
-      sources:
-        - type: git
-          url: https://gitlab.gnome.org/GNOME/libadwaita.git
-          tag: 1.2.beta
-          commit: 7387b453a4c93fbb60d68ec009af6f719fe8bab9
-      modules:
-        - name: libsass
-          buildsystem: meson
-          sources:
-            - type: git
-              url: https://github.com/lazka/libsass.git
-              branch: meson
-        - name: sassc
-          buildsystem: meson
-          sources:
-            - type: git
-              url: https://github.com/lazka/sassc.git
-              branch: meson
-    - name: python3-pytz
-      buildsystem: simple
-      sources:
-        - type: archive
-          url: https://files.pythonhosted.org/packages/2f/5f/a0f653311adff905bbcaa6d3dfaf97edcf4d26138393c6ccd37a484851fb/pytz-2022.1.tar.gz
-          sha256: 1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7
-      build-commands:
-        - ls
-        - pip3 install --prefix=/app .
-    - name: jadegui
-      buildsystem: meson
-      build-options:
-        build-args:
-          - --share=network
-      sources:
-          - type: dir
-            path: .
+{
+  "app-id": "al.getcryst.jadegui",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "43",
+  "sdk": "org.gnome.Sdk",
+  "command": "jade_gui",
+  "finish-args": [
+    "--share=network",
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--device=dri",
+    "--socket=wayland",
+    "--talk-name=org.freedesktop.Flatpak",
+    "--filesystem=home:rw"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/man",
+    "/share/doc",
+    "/share/gtk-doc",
+    "/share/pkgconfig",
+    "*.la",
+    "*.a"
+  ],
+  "modules": [
+    {
+      "name": "python3-pytz",
+      "buildsystem": "simple",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://files.pythonhosted.org/packages/2f/5f/a0f653311adff905bbcaa6d3dfaf97edcf4d26138393c6ccd37a484851fb/pytz-2022.1.tar.gz",
+          "sha256": "1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"
+        }
+      ],
+      "build-commands": [
+        "ls",
+        "pip3 install --prefix=/app ."
+      ]
+    },
+    {
+      "name": "jadegui",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "dir",
+          "path": "."
+        }
+      ]
+    }
+  ]
+}

--- a/src/classes/partition.py
+++ b/src/classes/partition.py
@@ -25,6 +25,9 @@ class Partition():
         self.size = size
 
     def generate_jade_entry(self):
-        return "/mnt"+self.mountpoint+":/dev/"+self.partition[5:]+":"+self.filesystem
+        mountpoint = "/mnt"+self.mountpoint
+        if self.mountpoint == "none":
+            mountpoint = "none"
+        return mountpoint+":/dev/"+self.partition[5:]+":"+self.filesystem
 
 


### PR DESCRIPTION
This changes the value to be only `none` instead of `/mntnone` when the user selects a partition that shouldn't be mounted.
Also bumps the runtime to org.gnome.Platform version 43 and removes the custom build libadwaita