### PR TITLE
Remove extra packages and change desktop entry

### DIFF
--- a/data/al.getcryst.jadegui.desktop.in
+++ b/data/al.getcryst.jadegui.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=jade_gui
+Name=jade GUI
 
 Exec=jade_gui
 

--- a/data/al.getcryst.jadegui.desktop.in
+++ b/data/al.getcryst.jadegui.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=jade GUI
+Name=Install Crystal Linux
 
 Exec=jade_gui
 

--- a/src/classes/install_prefs.py
+++ b/src/classes/install_prefs.py
@@ -91,7 +91,6 @@ class InstallPrefs:
             'desktop': self.desktop.lower(),
             'timeshift': self.timeshift_enabled,
             'extra_packages': [
-                'ttf-nerd-fonts-symbols-1000-em-mono',
                 'firefox'
             ],
             'flatpak': True,


### PR DESCRIPTION
This removes the nerd fonts extra package from the jade json since it's going to be installed by jade directly (https://github.com/crystal-linux/jade/pull/45).
It also changes the name entry in the .desktop file to be `Install Crystal Linux` to be more discoverable by the user