### PR TITLE
Make it work outside of flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,20 @@
 
 
 ### Building
-jade gui relies on a yet unreleased version of libadwaita, that's why you have to use flatpak to build it:
-
+Building as a flatpak (recommended for development)
 ```sh
 git clone https://github.com/crystal-linux/jade-gui
 cd jade-gui
 flatpak-builder --user --install --install-deps-from=flathub --force-clean build-dir al.getcryst.jadegui.yml
 flatpak run al.getcryst.jadegui
+```
+
+Building with meson
+```sh
+git clone https://github.com/crystal-linux/jade-gui
+cd jade-gui
+meson --prefix=/usr _build
+ninja -C _build
+cd _build
+sudo ninja install
 ```

--- a/src/functions/install_screen.py
+++ b/src/functions/install_screen.py
@@ -39,7 +39,7 @@ class InstallScreen(Adw.Bin):
     def install(self):
         prefs = self.window.summary_screen.installprefs.generate_json()
         with open(os.getenv("HOME")+"/jade-gui.log", "wb") as f:
-            process=subprocess.Popen(["bash", "-c", "bash -- /app/share/jade-gui/jade_gui/scripts/install.sh"], stdout=subprocess.PIPE)
+            process=subprocess.Popen(["bash", "-c", "bash -- /usr/share/jade-gui/jade_gui/scripts/install.sh"], stdout=subprocess.PIPE)
             for c in iter(lambda: process.stdout.read(1), b""):
                 log=c
                 try:

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/bash
 echo "Running reflector to sort for fastest mirrors"
-pkexec reflector --latest 5 --sort rate --save /etc/pacman.d/mirrorl
+pkexec reflector --latest 5 --sort rate --save /etc/pacman.d/mirrorlist
 pkexec jade config ~/.config/jade.json

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/bash
 echo "Running reflector to sort for fastest mirrors"
-flatpak-spawn --host pkexec reflector --latest 5 --sort rate --save /etc/pacman.d/mirrorlist
-flatpak-spawn --host pkexec jade config ~/.config/jade.json
+pkexec reflector --latest 5 --sort rate --save /etc/pacman.d/mirrorl
+pkexec jade config ~/.config/jade.json

--- a/src/utils/disks.py
+++ b/src/utils/disks.py
@@ -49,7 +49,7 @@ def get_disk_size(disk: str):
     return str(math.floor(int(size)/1000**3))+" GB"
 
 def get_uefi():
-    command=subprocess.run(["bash", "-c", "bash -- /app/share/jade-gui/jade_gui/scripts/checkEFI.sh"], capture_output=True)
+    command=subprocess.run(["bash", "-c", "[ -d /sys/firmware/efi ] && echo UEFI || echo BIOS"], capture_output=True)
     isEfi=True if command.stdout.decode('utf-8').strip('\n') == "UEFI" else False
     return isEfi
 


### PR DESCRIPTION
This makes jade-gui run as a flatpak, requires to be built with `--prefix=/usr`